### PR TITLE
Wrong description in truncate a string bonfire question.(Update basic-bonfires.json)

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -440,7 +440,7 @@
       "description": [
         "Truncate a string (first argument) if it is longer than the given maximum string length (second argument). Return the truncated string with a \"...\" ending.",
         "Note that the three dots at the end add to the string length.",
-        "If the length of the string is less than or equal to 3 characters, then the length of the three dots is not added to the string length.",
+        "If num is less than or equal to 3, then the length of the three dots is not added to the string length.",
         "Remember to use <a href=\"//github.com/FreeCodeCamp/freecodecamp/wiki/How-to-get-help-when-you-get-stuck\" target=\"_blank\">Read-Search-Ask</a> if you get stuck. Write your own code."
       ],
       "challengeSeed": [


### PR DESCRIPTION
In the question description the following section -
" If the length of the string is less than or equal to 3 characters, then the length of the three dots is not added to the string length.".
This should be stated as follwoing to get the code accepted -
" If the num is less than 3, then the length of the three dots is not added to the string length."
I had solved all the problems in algorithm scripting but this one because according to previous description my code was not getting accepted.
As soon as I wrote the code for the new description I got my code accepted.
